### PR TITLE
Add symlink to the latest version of the Saturn core

### DIFF
--- a/saturn-updater-workflow-builds.sh
+++ b/saturn-updater-workflow-builds.sh
@@ -74,6 +74,7 @@ else
   fi
 fi
 
+ln -sf "$corefile" "$coredir/ Saturn_latest.rbf"
 
 [ -n "$maxkeep" -a -n "$coredir" -a -n "$corename" ] \
   && { ls -t "${coredir}/${corename}_"*".rbf"|awk "NR>$maxkeep"|xargs -r rm;}


### PR DESCRIPTION
Create a symlink to the latest version of the core after it has been downloaded like @Akuma-Git's PSX updater script [does](https://github.com/Akuma-Git/misterfpga/blob/main/unstable-update_psx-nightlies.sh#L93). This is handy when there are multiple versions of the core and you want to quickly access the latest one.